### PR TITLE
Introduce auto publish image to ghcr.io for amd64 and aarch64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,97 @@
+name: Publish container image
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -79,7 +79,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64 #,linux/arm/v7
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
Heya
It's easier for users to pull a premade image (because compiling takes quite a bit, in github about 120mins)
It's tested and works:
https://github.com/Macleykun/JitStreamer-EB/pkgs/container/jitstreamer-eb

Source: https://github.com/Macleykun/JitStreamer-EB/actions/runs/13353923593/job/37294034019
Only armv7 doesn't work:
```
#19 ...

#41 [linux/arm/v7 builder 4/7] RUN git clone https://github.com/jkcoxson/netmuxd.git &&     cd netmuxd &&     git reset --hard ec02699ca6fa5979f875ef682dedd6c7597f06db &&     cargo build --release &&     cd ..
#41 0.175 Cloning into 'netmuxd'...
#41 2.194 HEAD is now at ec02699 Bind mac_addr in match statement
#41 4.382     Updating crates.io index
#41 4.396     Updating git repository `[https://github.com/zeyugao/zeroconf-rs`](https://github.com/zeyugao/zeroconf-rs%60)
#41 4.724 warning: spurious network error (3 tries remaining): could not read directory '/usr/local/cargo/git/db/zeroconf-rs-4c1119850e5ab051/refs': Value too large for defined data type; class=Os (2)
#41 5.660 warning: spurious network error (2 tries remaining): could not read directory '/usr/local/cargo/git/db/zeroconf-rs-4c1119850e5ab051/refs': Value too large for defined data type; class=Os (2)
#41 9.347 warning: spurious network error (1 tries remaining): could not read directory '/usr/local/cargo/git/db/zeroconf-rs-4c1119850e5ab051/refs': Value too large for defined data type; class=Os (2)
#41 16.09 error: failed to get `zeroconf` as a dependency of package `netmuxd v0.2.1 (/app/netmuxd)`
#41 16.09 
#41 16.09 Caused by:
#41 16.09   failed to load source for dependency `zeroconf`
#41 16.09 
#41 16.09 Caused by:
#41 16.09   Unable to update https://github.com/zeyugao/zeroconf-rs#860b0300
#41 16.09 
#41 16.09 Caused by:
#41 16.09   failed to clone into: /usr/local/cargo/git/db/zeroconf-rs-4c1119850e5ab051
#41 16.09 
#41 16.09 Caused by:
#41 16.09   revision 860b030064308d4318e2c6936886674d955c6472 not found
#41 16.09 
#41 16.09 Caused by:
#41 16.09   could not read directory '/usr/local/cargo/git/db/zeroconf-rs-4c1119850e5ab051/refs': Value too large for defined data type; class=Os (2)
#41 ERROR: process "/dev/.buildkit_qemu_emulator /bin/sh -c git clone https://github.com/jkcoxson/netmuxd.git &&     cd netmuxd &&     git reset --hard ec02699ca6fa5979f875ef682dedd6c7597f06db &&     cargo build --release &&     cd .." did not complete successfully: exit code: 101

#19 [linux/arm/v7 stage-1  2/12] RUN apt-get update && apt-get install -y     python3     python3-pip     wireguard-tools     iproute2     librust-openssl-dev     libssl-dev &&     rm -rf /var/lib/apt/lists/*
#19 CANCELED

#23 [linux/arm64 builder 2/7] RUN apt-get update && apt-get install -y     python3     python3-pip     wireguard-tools &&     rm -rf /var/lib/apt/lists/*
#23 CANCELED

#21 [linux/arm64 stage-1  2/12] RUN apt-get update && apt-get install -y     python3     python3-pip     wireguard-tools     iproute2     librust-openssl-dev     libssl-dev &&     rm -rf /var/lib/apt/lists/*
#21 CANCELED
------
 > [linux/arm/v7 builder 4/7] RUN git clone https://github.com/jkcoxson/netmuxd.git &&     cd netmuxd &&     git reset --hard ec02699ca6fa5979f875ef682dedd6c7597f06db &&     cargo build --release &&     cd ..:
16.09   Unable to update https://github.com/zeyugao/zeroconf-rs#860b0300
16.09 
16.09 Caused by:
16.09   failed to clone into: /usr/local/cargo/git/db/zeroconf-rs-4c1119850e5ab051
16.09 
16.09 Caused by:
16.09   revision 860b030064308d4318e2c6936886674d955c6472 not found
16.09 
16.09 Caused by:
16.09   could not read directory '/usr/local/cargo/git/db/zeroconf-rs-4c1119850e5ab051/refs': Value too large for defined data type; class=Os (2)
------
dockerfile:18
--------------------
  17 |     # Clone and build netmuxd
  18 | >>> RUN git clone https://github.com/jkcoxson/netmuxd.git && \
  19 | >>>     cd netmuxd && \
  20 | >>>     git reset --hard ec02699ca6fa5979f875ef682dedd6c7597f06db && \
  21 | >>>     cargo build --release && \
  22 | >>>     cd ..
  23 |     
--------------------
ERROR: failed to solve: process "/dev/.buildkit_qemu_emulator /bin/sh -c git clone https://github.com/jkcoxson/netmuxd.git &&     cd netmuxd &&     git reset --hard ec02699ca6fa5979f875ef682dedd6c7597f06db &&     cargo build --release &&     cd .." did not complete successfully: exit code: 101
Error: buildx failed with: ERROR: failed to solve: process "/dev/.buildkit_qemu_emulator /bin/sh -c git clone https://github.com/jkcoxson/netmuxd.git &&     cd netmuxd &&     git reset --hard ec02699ca6fa5979f875ef682dedd6c7597f06db &&     cargo build --release &&     cd .." did not complete successfully: exit code
```
Source: https://github.com/Macleykun/JitStreamer-EB/actions/runs/13353648393/job/37293382908